### PR TITLE
Fix class name @var value

### DIFF
--- a/wordpress-plugin-boilerplate/wordpress-plugin-boilerplate.php
+++ b/wordpress-plugin-boilerplate/wordpress-plugin-boilerplate.php
@@ -48,7 +48,7 @@ final class Plugin_Name {
 	/**
 	 * The single instance of the class
 	 *
-	 * @var Plugin Name
+	 * @var Plugin_Name
 	 */
 	protected static $_instance = null;
 


### PR DESCRIPTION
Missing an underscore, the replace script is missing it, must be same as
plugin class.
